### PR TITLE
Fix for issue: Folder in Folder and Options Dialog no longer gets saved #8

### DIFF
--- a/MsCrmTools.WebResourcesManager/WebResourcesManager.cs
+++ b/MsCrmTools.WebResourcesManager/WebResourcesManager.cs
@@ -369,6 +369,11 @@ namespace MsCrmTools.WebResourcesManager
                 // Let the user decides where to find files
                 var fbd = new CustomFolderBrowserDialog(true);
 
+                if (string.IsNullOrWhiteSpace(currentFolderForFiles))
+                {
+                    currentFolderForFiles = Options.Instance.LastFolderUsed;
+                }
+
                 if (!string.IsNullOrEmpty(currentFolderForFiles))
                 {
                     fbd.FolderPath = currentFolderForFiles;
@@ -377,6 +382,8 @@ namespace MsCrmTools.WebResourcesManager
                 if (fbd.ShowDialog() == DialogResult.OK)
                 {
                     currentFolderForFiles = fbd.FolderPath;
+                    var options = Options.Instance;
+                    options.LastFolderUsed = currentFolderForFiles;
                     Options.Instance.Save();
 
                     var invalidFilenames = webresourceTreeView1.LoadWebResourcesFromDisk(fbd.FolderPath, fbd.ExtensionsToLoad);
@@ -432,6 +439,11 @@ namespace MsCrmTools.WebResourcesManager
         {
             var fbd = new CustomFolderBrowserDialog(true, false);
 
+            if (string.IsNullOrWhiteSpace(currentFolderForFiles))
+            {
+                currentFolderForFiles = Options.Instance.LastFolderUsed;
+            }
+
             if (!string.IsNullOrEmpty(currentFolderForFiles))
             {
                 fbd.FolderPath = currentFolderForFiles;
@@ -440,6 +452,8 @@ namespace MsCrmTools.WebResourcesManager
             if (fbd.ShowDialog() == DialogResult.OK)
             {
                 currentFolderForFiles = fbd.FolderPath;
+                var options = Options.Instance;
+                options.LastFolderUsed = currentFolderForFiles;
                 Options.Instance.Save();
                 foreach (var resource in resources)
                 {


### PR DESCRIPTION
This potentially should be moved into the CustomFolderBrowserDialog, so whenever someone clicks ok, it saves the values, and it loads the values on Load.  This would create a dependency in the CustomFolderBrowserDialog to the Options class, so not sure if this is desired or not...