### PR TITLE
Check added to avoid Exception when loading an empty web resource

### DIFF
--- a/MsCrmTools.WebResourcesManager/AppCode/JsBeautifier/Beautifier.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/JsBeautifier/Beautifier.cs
@@ -50,6 +50,8 @@
 
             this.BlankState();
 
+            s = string.IsNullOrWhiteSpace(s) ? string.Empty : s;
+
             while (s.Length != 0 && (s[0] == ' ' || s[0] == '\t'))
             {
                 this.PreindentString += s[0];
@@ -99,6 +101,8 @@
 
         private void Append(string s)
         {
+            s = string.IsNullOrWhiteSpace(s) ? string.Empty : s;
+
             if (s == " ")
             {
                 // do not add just a single space after the // comment, ever


### PR DESCRIPTION
Added a null-check on the 's' variable involved with the Js rendering. This makes it possible to display empty web resources, as opposed to throwing an exception.

This mitigates the inconvenience caused by the currently present issue where web resources are sometimes cleared of all contents when publishing.