### PR TITLE
Further check added to prevent exception when loading an empty webresource

### DIFF
--- a/MsCrmTools.WebResourcesManager/UserControls/CodeEditorScintilla.cs
+++ b/MsCrmTools.WebResourcesManager/UserControls/CodeEditorScintilla.cs
@@ -48,8 +48,12 @@ namespace MscrmTools.WebResourcesManager.UserControls
             this.resource = resource;
             this.options = options;
 
-            byte[] b = Convert.FromBase64String(resource.EntityContent);
-            innerContent = Encoding.UTF8.GetString(b);
+            innerContent = string.Empty;
+            if (!string.IsNullOrWhiteSpace(resource.EntityContent))
+            {
+                byte[] b = Convert.FromBase64String(resource.EntityContent);
+                innerContent = Encoding.UTF8.GetString(b);
+            }
             originalContent = innerContent;
             //innerType = type;
 


### PR DESCRIPTION
This change should let the editor handle any empty web resource, either new or suffering from the bug that uploads and publishes empty content instead of the actual content of the web resource.

Expected result: Selecting an empty web resource should show an empty editor, allowing editing and re-uploading of lost content.