### PR TITLE
Lazy loading

### DIFF
--- a/MsCrmTools.WebResourcesManager/AppCode/Settings.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/Settings.cs
@@ -111,8 +111,8 @@ namespace MscrmTools.WebresourcesManager.AppCode
         public bool LoadSystemHiddenResources { get; set; }
 
         [Category("Loading Settings")]
-        [DisplayName("Lazy Loading Of WebResources")]
-        [Description("Determines if web resources content loaded when you open it first time or during loading of the web resources tree")]
+        [DisplayName("Lazy loading of webresources")]
+        [Description("Determines if a web resource content should be loaded when you open it first time or during loading of the web resources tree")]
         public bool LazyLoadingOfWebResources { get; set; } = false;
 
         [Category("Local Sync Settings")]

--- a/MsCrmTools.WebResourcesManager/AppCode/Settings.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/Settings.cs
@@ -110,6 +110,11 @@ namespace MscrmTools.WebresourcesManager.AppCode
         [Description("Specify wether to load system webresources that are normaly hidden. Only works when loading webresources without specifying a solution to load")]
         public bool LoadSystemHiddenResources { get; set; }
 
+        [Category("Loading Settings")]
+        [DisplayName("Lazy Loading Of WebResources")]
+        [Description("Determines if web resources content loaded when you open it first time or during loading of the web resources tree")]
+        public bool LazyLoadingOfWebResources { get; set; } = false;
+
         [Category("Local Sync Settings")]
         [DisplayName("Local files out of date on load")]
         [Description("Treats local files as out of date when they are initially loaded.  Setting to false will only track future changes.")]

--- a/MsCrmTools.WebResourcesManager/AppCode/Solution.Static.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/Solution.Static.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MscrmTools.WebresourcesManager.AppCode
+{
+    public static partial class Solution
+    {
+        public static ColumnSet Columns = new ColumnSet("solutionid", "friendlyname", "version", "publisherid", "uniquename");
+    }
+}

--- a/MsCrmTools.WebResourcesManager/AppCode/WebResource.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/WebResource.cs
@@ -591,7 +591,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
             {
                 if (overwrite == false)
                 {
-                    var existingRecord = service.Retrieve("webresource", record.Id, new ColumnSet());
+                    var existingRecord = service.Retrieve("webresource", record.Id, new ColumnSet(false));
                     if (!string.IsNullOrEmpty(existingRecord.RowVersion) && !string.IsNullOrEmpty(record.RowVersion) && long.Parse(existingRecord.RowVersion) > long.Parse(record.RowVersion))
                     {
                         throw new MoreRecentRecordExistsException();
@@ -648,7 +648,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
             // Find if the web resource is attached to solutions
             var solutions = Plugin.Service.RetrieveMultiple(new QueryExpression("solution")
             {
-                ColumnSet = Webresource.Columns,
+                ColumnSet = Solution.Columns,
                 Criteria = new FilterExpression
                 {
                     Conditions =

--- a/MsCrmTools.WebResourcesManager/AppCode/WebResource.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/WebResource.cs
@@ -396,6 +396,12 @@ namespace MscrmTools.WebresourcesManager.AppCode
             }
         }
 
+        [DisplayName("IsLoaded")]
+        [Browsable(false)]
+        [Description("Shows if webresource content was loaded")]
+        [ReadOnly(true)]
+        public bool IsLoaded => !(string.IsNullOrWhiteSpace(Content) && string.IsNullOrWhiteSpace(StringContent));
+
         #endregion Properties
 
         #region Events
@@ -789,6 +795,14 @@ namespace MscrmTools.WebresourcesManager.AppCode
             entity["name"] = name;
             entity["displayname"] = displayName ?? name;
             return new Webresource(entity, Plugin);
+        }
+
+        public void LazyLoadWebResource(IOrganizationService service)
+        {
+            Content = RetrieveWebresource(Id, service).GetAttributeValue<string>("content");
+            StringContent = GetPlainText();
+
+            State = WebresourceState.None;
         }
 
         #endregion Methods

--- a/MsCrmTools.WebResourcesManager/AppCode/WebResource.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/WebResource.cs
@@ -648,7 +648,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
             // Find if the web resource is attached to solutions
             var solutions = Plugin.Service.RetrieveMultiple(new QueryExpression("solution")
             {
-                ColumnSet = new ColumnSet(true),
+                ColumnSet = Webresource.Columns,
                 Criteria = new FilterExpression
                 {
                     Conditions =

--- a/MsCrmTools.WebResourcesManager/AppCode/Webresource.BulkStatic.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/Webresource.BulkStatic.cs
@@ -17,6 +17,11 @@ namespace MscrmTools.WebresourcesManager.AppCode
             "webresourcetype", "displayname", "modifiedon", "createdby", 
             "webresourceid", "description", "content");
 
+        public static readonly ColumnSet LazyLoadingColumns = new ColumnSet(
+            "languagecode", "createdon", "name", "dependencyxml", "modifiedby",
+            "webresourcetype", "displayname", "modifiedon", "createdby",
+            "webresourceid", "description");
+
         public static readonly Regex InValidWrNameRegex = new Regex("[^a-z0-9A-Z_\\./]|[/]{2,}", (RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase));
         public static readonly Regex InValidWrNameRegexForV9 = new Regex("[^a-z0-9A-Z_\\-\\./]|[/]{2,}", (RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase));
         private static readonly HashSet<string> ExtensionsToSkipLoadingErrorMessage = new HashSet<string> { "map", "ts" };
@@ -220,7 +225,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                     return resources;
                 }
 
-                var qba = new QueryByAttribute("solutioncomponent") { ColumnSet = Webresource.Columns };
+                var qba = new QueryByAttribute("solutioncomponent") { ColumnSet = new ColumnSet("objectid") };
                 qba.Attributes.AddRange("solutionid", "componenttype");
                 qba.Values.AddRange(solutionId, 61);
 

--- a/MsCrmTools.WebResourcesManager/AppCode/Webresource.BulkStatic.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/Webresource.BulkStatic.cs
@@ -148,6 +148,21 @@ namespace MscrmTools.WebresourcesManager.AppCode
             }
         }
 
+        public static Entity RetrieveWebresource(Guid id, IOrganizationService service)
+        {
+            try
+            {
+                if (id == null || id == Guid.Empty)
+                    throw new Exception($"WebResource id is null or empty");
+
+                return service.Retrieve("webresource", id, Webresource.Columns);
+            }
+            catch (Exception error)
+            {
+                throw new Exception($"An error occured while retrieving a webresource with id {id}: {error.Message}");
+            }
+        }
+
         public static IEnumerable<Webresource> RetrieveWebresources(MyPluginControl parent, IOrganizationService service, Guid solutionId, List<int> types, bool filterByLcid = false, params int[] lcids)
         {
             try
@@ -156,7 +171,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                 {
                     var qe = new QueryExpression("webresource")
                     {
-                        ColumnSet = Webresource.Columns,
+                        ColumnSet = Settings.Instance.LazyLoadingOfWebResources ? Webresource.LazyLoadingColumns : Webresource.Columns,
                         Criteria = new FilterExpression
                         {
                             Filters =
@@ -239,7 +254,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                 {
                     var qe = new QueryExpression("webresource")
                     {
-                        ColumnSet = Webresource.Columns,
+                        ColumnSet = Settings.Instance.LazyLoadingOfWebResources ? Webresource.LazyLoadingColumns : Webresource.Columns,
                         Criteria = new FilterExpression
                         {
                             Filters =

--- a/MsCrmTools.WebResourcesManager/AppCode/Webresource.BulkStatic.cs
+++ b/MsCrmTools.WebResourcesManager/AppCode/Webresource.BulkStatic.cs
@@ -12,6 +12,11 @@ namespace MscrmTools.WebresourcesManager.AppCode
 {
     public partial class Webresource
     {
+        public static readonly ColumnSet Columns = new ColumnSet(
+            "languagecode", "createdon", "name", "dependencyxml", "modifiedby", 
+            "webresourcetype", "displayname", "modifiedon", "createdby", 
+            "webresourceid", "description", "content");
+
         public static readonly Regex InValidWrNameRegex = new Regex("[^a-z0-9A-Z_\\./]|[/]{2,}", (RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase));
         public static readonly Regex InValidWrNameRegexForV9 = new Regex("[^a-z0-9A-Z_\\-\\./]|[/]{2,}", (RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase));
         private static readonly HashSet<string> ExtensionsToSkipLoadingErrorMessage = new HashSet<string> { "map", "ts" };
@@ -121,7 +126,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                 var qba = new QueryByAttribute("webresource");
                 qba.Attributes.Add("name");
                 qba.Values.Add(name);
-                qba.ColumnSet = new ColumnSet(true);
+                qba.ColumnSet = Webresource.Columns;
 
                 EntityCollection collection = service.RetrieveMultiple(qba);
 
@@ -146,7 +151,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                 {
                     var qe = new QueryExpression("webresource")
                     {
-                        ColumnSet = new ColumnSet(true),
+                        ColumnSet = Webresource.Columns,
                         Criteria = new FilterExpression
                         {
                             Filters =
@@ -215,7 +220,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                     return resources;
                 }
 
-                var qba = new QueryByAttribute("solutioncomponent") { ColumnSet = new ColumnSet(true) };
+                var qba = new QueryByAttribute("solutioncomponent") { ColumnSet = Webresource.Columns };
                 qba.Attributes.AddRange("solutionid", "componenttype");
                 qba.Values.AddRange(solutionId, 61);
 
@@ -229,7 +234,7 @@ namespace MscrmTools.WebresourcesManager.AppCode
                 {
                     var qe = new QueryExpression("webresource")
                     {
-                        ColumnSet = new ColumnSet(true),
+                        ColumnSet = Webresource.Columns,
                         Criteria = new FilterExpression
                         {
                             Filters =

--- a/MsCrmTools.WebResourcesManager/Forms/SolutionPicker.cs
+++ b/MsCrmTools.WebResourcesManager/Forms/SolutionPicker.cs
@@ -82,7 +82,7 @@ namespace MscrmTools.WebresourcesManager.Forms
             {
                 QueryExpression qe = new QueryExpression("solution");
                 qe.Distinct = true;
-                qe.ColumnSet = new ColumnSet("solutionid", "friendlyname", "version", "publisherid", "uniquename");
+                qe.ColumnSet = Solution.Columns;
                 qe.Criteria = new FilterExpression();
                 qe.Criteria.AddCondition(new ConditionExpression("ismanaged", ConditionOperator.Equal, false));
                 qe.Criteria.AddCondition(new ConditionExpression("isvisible", ConditionOperator.Equal, true));
@@ -107,7 +107,7 @@ namespace MscrmTools.WebresourcesManager.Forms
             {
                 QueryExpression qe = new QueryExpression("solution");
                 qe.Distinct = true;
-                qe.ColumnSet = new ColumnSet("solutionid", "friendlyname", "version", "publisherid", "uniquename");
+                qe.ColumnSet = Solution.Columns;
                 qe.Criteria = new FilterExpression();
                 qe.Criteria.AddCondition(new ConditionExpression("friendlyname", ConditionOperator.Like, $"%{friendlyName}%"));
                 qe.Criteria.AddCondition(new ConditionExpression("ismanaged", ConditionOperator.Equal, false));

--- a/MsCrmTools.WebResourcesManager/MsCrmTools.WebResourcesManager.csproj
+++ b/MsCrmTools.WebResourcesManager/MsCrmTools.WebResourcesManager.csproj
@@ -190,6 +190,7 @@
     <Compile Include="AppCode\ListViewItemComparer.cs" />
     <Compile Include="AppCode\LoadResourcesSettings.cs" />
     <Compile Include="AppCode\Settings.cs" />
+    <Compile Include="AppCode\Solution.Static.cs" />
     <Compile Include="AppCode\TreeNodeSorter.cs" />
     <Compile Include="AppCode\UpdateResourcesResult.cs" />
     <Compile Include="AppCode\UpdateResourcesSettings.cs" />

--- a/MsCrmTools.WebResourcesManager/MyPluginControl.cs
+++ b/MsCrmTools.WebResourcesManager/MyPluginControl.cs
@@ -392,6 +392,33 @@ Are you sure you want to delete this webresource?",
                 return;
             }
 
+            if (!resource.IsLoaded)
+            {
+                LazyLoadWebResource(resource);
+            }
+            else
+            {
+                DisplayContentForm(resource);
+            }
+        }
+
+        private void LazyLoadWebResource(Webresource resource)
+        {
+            WorkAsync(
+                new WorkAsyncInfo("Loading web resource...", e =>
+                {
+                    resource.LazyLoadWebResource(Service);
+                })
+                {
+                    PostWorkCallBack = e =>
+                    {
+                        DisplayContentForm(resource);
+                    }
+                });
+        }
+
+        private void DisplayContentForm(Webresource resource)
+        {
             BaseContentForm content = null;
 
             switch (resource.Type)


### PR DESCRIPTION
- Added an ability to load content of webresources when a resource is opened first time, not during initial web resources tree build-up. Option can be enabled by switching to "True" "Lazy loading of webresources" option in settings window.
- Moved ColumnSets for webresource and solution to static constants for easier maintaining.
- Used an explicitly specified columns instead of ColumnSet(true) and ColumnSet().